### PR TITLE
feat(ui): トップページをモダン化し、TodosClient をリスタイル

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,14 +2,39 @@ import { db } from "@/lib/db";
 import TodosClient from "@/components/TodosClient";
 
 export default async function Page() {
-  const initialTodos = await db.list(); // サーバーで直読み
+  const initialTodos = await db.list();
   return (
-    <main style={{ maxWidth: 680, margin: "40px auto", padding: 16 }}>
-      <h1 style={{ fontSize: 28, fontWeight: 700, marginBottom: 16 }}>Optimistic CRUD Demo</h1>
-      <TodosClient initialTodos={initialTodos} />
-      <p style={{ marginTop: 24, opacity: 0.6 }}>
-        初期描画はサーバーでデータを読み込み、TanStack Query の <code>initialData</code> に渡しています。
-      </p>
+    <main className="relative px-4 py-10 md:py-16 font-sans">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 overflow-hidden"
+      >
+        <div className="mx-auto h-64 w-[40rem] max-w-[90%] -translate-y-10 rounded-full bg-gradient-to-tr from-indigo-500/20 via-sky-500/10 to-transparent blur-3xl dark:from-indigo-400/20 dark:via-sky-400/10" />
+      </div>
+
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-8 text-center md:mb-12">
+          <span className="inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-500/10 px-3 py-1 text-xs font-medium text-indigo-700 dark:text-indigo-300">
+            TanStack Query × Next.js App Router
+          </span>
+          <h1 className="mt-3 bg-gradient-to-r from-zinc-900 to-zinc-600 bg-clip-text text-3xl font-semibold tracking-tight text-transparent dark:from-zinc-100 dark:to-zinc-400 md:text-5xl">
+            Optimistic CRUD Demo
+          </h1>
+          <p className="mx-auto mt-3 max-w-2xl text-sm text-zinc-600 dark:text-zinc-400 md:text-base">
+            サーバーで初期データを描画し、クライアントでは TanStack Query でハイドレート。高速で心地よい操作感の Todo を体験してください。
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-200 bg-white/60 p-4 shadow-lg backdrop-blur-sm dark:border-zinc-800 dark:bg-zinc-900/40 md:p-6">
+          <TodosClient initialTodos={initialTodos} />
+        </div>
+
+        <p className="mx-auto mt-6 max-w-2xl text-center text-sm text-zinc-500 dark:text-zinc-500">
+          初期描画はサーバーから <code>db.list()</code> を読み込み、結果を TanStack Query の
+          <code className="mx-1">initialData</code> に渡しています。クライアント更新は楽観的に反映し、
+          後続で同期を取ります。
+        </p>
+      </div>
     </main>
   );
 }

--- a/src/components/TodosClient.tsx
+++ b/src/components/TodosClient.tsx
@@ -96,77 +96,68 @@ export default function TodosClient({ initialTodos }: { initialTodos: Todo[] }) 
           if (!title.trim()) return;
           addMutation.mutate(title.trim());
         }}
-        style={{ display: "flex", gap: 8, marginBottom: 16 }}
+        className="mb-6 flex gap-3"
       >
         <input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="新規タスク..."
-          style={{ flex: 1, padding: "8px 10px", border: "1px solid #ddd", borderRadius: 8 }}
+          className="flex-1 rounded-xl border border-zinc-200 bg-white/70 px-3 py-2 text-zinc-900 shadow-sm outline-none placeholder:text-zinc-400 focus:ring-2 focus:ring-indigo-500 dark:border-zinc-800 dark:bg-zinc-900/50 dark:text-zinc-100"
         />
         <button
           type="submit"
           disabled={addMutation.isPending}
-          style={{ padding: "8px 12px", borderRadius: 8, border: "1px solid #ddd" }}
+          className="rounded-xl bg-indigo-600 px-4 py-2 text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
         >
           追加
         </button>
       </form>
 
-      <ul style={{ display: "grid", gap: 8 }}>
-        {todos.map((t) => (
-          <li
-            key={t.id}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              padding: 10,
-              border: "1px solid #eee",
-              borderRadius: 12,
-              opacity: t.id.startsWith("temp-") ? 0.6 : 1,
-            }}
-          >
-            <input
-              type="checkbox"
-              checked={t.done}
-              onChange={() => updateMutation.mutate({ id: t.id, patch: { done: !t.done } })}
-              aria-label="完了切替"
-            />
-            <span
-              style={{
-                flex: 1,
-                textDecoration: t.done ? "line-through" : "none",
-                opacity: t.done ? 0.6 : 1,
-                wordBreak: "break-all",
-              }}
+      <ul className="grid gap-3">
+        {todos.map((t) => {
+          const isTemp = t.id.startsWith("temp-");
+          return (
+            <li
+              key={t.id}
+              className={`flex items-center gap-3 rounded-xl border border-zinc-200 bg-white/70 p-3 shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900/50 ${isTemp ? "opacity-60" : ""}`}
             >
-              {t.title}
-            </span>
+              <input
+                type="checkbox"
+                checked={t.done}
+                onChange={() => updateMutation.mutate({ id: t.id, patch: { done: !t.done } })}
+                aria-label="完了切替"
+                className="size-4 accent-indigo-600"
+              />
+              <span
+                className={`flex-1 break-words ${t.done ? "line-through opacity-60" : ""}`}
+              >
+                {t.title}
+              </span>
 
-            <button
-              onClick={() => {
-                const next = window.prompt("タイトルを編集", t.title);
-                if (next && next.trim() && next !== t.title) {
-                  updateMutation.mutate({ id: t.id, patch: { title: next.trim() } });
-                }
-              }}
-              style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #ddd" }}
-            >
-              編集
-            </button>
+              <button
+                onClick={() => {
+                  const next = window.prompt("タイトルを編集", t.title);
+                  if (next && next.trim() && next !== t.title) {
+                    updateMutation.mutate({ id: t.id, patch: { title: next.trim() } });
+                  }
+                }}
+                className="rounded-lg border border-zinc-200 px-3 py-1.5 text-sm text-zinc-700 transition hover:bg-zinc-50 dark:border-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-800"
+              >
+                編集
+              </button>
 
-            <button
-              onClick={() => deleteMutation.mutate(t.id)}
-              style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #ddd" }}
-            >
-              削除
-            </button>
-          </li>
-        ))}
+              <button
+                onClick={() => deleteMutation.mutate(t.id)}
+                className="rounded-lg border border-zinc-200 px-3 py-1.5 text-sm text-zinc-700 transition hover:bg-zinc-50 dark:border-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-800"
+              >
+                削除
+              </button>
+            </li>
+          );
+        })}
       </ul>
 
-      <div style={{ marginTop: 12, fontSize: 12, opacity: 0.7 }}>
+      <div className="mt-3 text-xs text-zinc-500 dark:text-zinc-500">
         {isFetching ? "同期中..." : "最新です"}
       </div>
     </section>


### PR DESCRIPTION
- グラデーションのヒーローとセンタリング見出しを追加\n- Todo をガラス風カードで囲い、角丸・境界線・影を付与\n- 入力欄/ボタン/リストを Tailwind ベースで再設計\n- SSR 初期データと楽観的 CRUD は維持\n- ダークモードの視認性を調整